### PR TITLE
Use "native" target for jvm-toxcore-c.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@ scala_binary(
     srcs = glob([
         "src/main/scala/**/*.scala",
     ]),
-    data = ["//jvm-toxcore-c:libtox4j-c.so"],
+    data = ["//jvm-toxcore-c:native"],
     jvm_flags = ["-Djava.library.path=jvm-toxcore-c"],
     main_class = "im.tox.streambot.StreamBot",
     resources = glob([
@@ -18,9 +18,9 @@ scala_binary(
         "@log4j_log4j//jar",
         "@org_bytedeco_javacpp//jar",
         "@org_bytedeco_javacpp_presets_ffmpeg//jar",
-        "@org_bytedeco_javacpp_presets_ffmpeg_linux_x86_64//jar",
+        "@org_bytedeco_javacpp_presets_ffmpeg_platform//jar",
         "@org_bytedeco_javacpp_presets_opencv//jar",
-        "@org_bytedeco_javacpp_presets_opencv_linux_x86_64//jar",
+        "@org_bytedeco_javacpp_presets_opencv_platform//jar",
         "@org_bytedeco_javacv//jar",
         "@org_slf4j_slf4j_log4j12//jar",
     ],


### PR DESCRIPTION
This selects the .so or .dylib depending on target platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/streambot-jvm/6)
<!-- Reviewable:end -->
